### PR TITLE
lazily evaluate environment variables during execute blocks

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eric.hanko1@gmail.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring a VSTS build/release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.7'
+version '1.2.8'
 chef_version '>= 13.0' if respond_to?(:chef_version)
 
 source_url 'https://github.com/americanhanko/vsts-agent-macos-cookbook'

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -61,7 +61,7 @@ execute 'bootstrap the agent' do
   cwd Agent.agent_home
   user Agent.admin_user
   command ['./bin/Agent.Listener', 'configure', '--unattended', '--acceptTeeEula']
-  environment Agent.vsts_environment
+  environment lazy { Agent.vsts_environment }
   not_if { Agent.credentials? }
   live_stream true
   ignore_failure true
@@ -81,7 +81,7 @@ execute 'configure replacement agent' do
   cwd Agent.agent_home
   user Agent.admin_user
   command ['./bin/Agent.Listener', 'configure', '--replace', '--unattended', '--acceptTeeEula']
-  environment Agent.vsts_environment
+  environment lazy { Agent.vsts_environment }
   live_stream true
   action :nothing
   notifies :restart, 'macosx_service[vsts agent launch agent]'

--- a/recipes/teardown.rb
+++ b/recipes/teardown.rb
@@ -20,7 +20,7 @@ execute 'unconfigure VSTS agent' do
   cwd Agent.agent_home
   user Agent.admin_user
   command ['./bin/Agent.Listener', 'remove']
-  environment Agent.vsts_environment
+  environment lazy { Agent.vsts_environment }
   live_stream true
   action :nothing
   subscribes :delete, 'file[delete service name file]', :immediately


### PR DESCRIPTION
This PR lazily evaluates environment variables during `execute` blocks in case something has changed mid-run, like `node['hostname']`.