### PR TITLE
Feature/deployment groups

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,8 +11,8 @@ provisioner:
   require_chef_omnibus: true
 
 platforms:
-- name: apex/macos-10.12.6
-- name: apex/macos-10.13.3
+- name: microsoft/macos-sierra
+- name: microsoft/macos-high-sierra
 
 verifier:
   name: inspec
@@ -34,6 +34,29 @@ suites:
       additional_environment:
         VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
         MEAL_ENDS_WITH: sauce
+    homebrew:
+      auto-update: false
+      owner: vagrant
+
+- name: deployment_target
+  run_list:
+  - recipe[vsts_agent_macos::default]
+  verifier:
+    sudo: false
+    inspec_tests:
+    - test/integration/default
+  attributes:
+    vsts_agent:
+      deployment_pool: macOS Netboot
+      account: office
+      data_bag: vsts
+      data_bag_item: office_build_agent
+      deployment_target: true
+      project: APEX
+      work: _work
+      additional_environment:
+        VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
+        MEAL_STARTS_WITH: noodles
     homebrew:
       auto-update: false
       owner: vagrant

--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ report back to the server.
 default['vsts_agent']['additional_environment']
 ```
 
+Deployment Groups
+-----------------
+
+This cookbook supports adding release targets to VSTS Deployment groups. To use this feature,
+set the `default['vsts_agent']['deployment_target']` to `true` and make sure you have the appropriate
+values set for the following attributes (default values are shown below):
+
+```ruby
+default['vsts_agent']['deployment_pool'] = "American Hanko's Deployment Targets"
+default['vsts_agent']['project'] = 'American Hanko'
+default['vsts_agent']['work'] = '_work'
+```
+
 Required Data Bag Item
 ----------------------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,13 @@ default['vsts_agent']['data_bag_item'] = 'build_agent'
 
 default['vsts_agent']['agent_name'] = node['hostname']
 default['vsts_agent']['account'] = 'americanhanko'
-default['vsts_agent']['agent_pool'] = "American Hanko's Agents"
-default['vsts_agent']['version'] = '2.131.0'
+default['vsts_agent']['agent_pool'] = "American Hanko's Build Agents"
+
+default['vsts_agent']['version'] = '2.134.2'
 default['vsts_agent']['additional_environment'] = {}
 default['vsts_agent']['service_name'] = 'com.microsoft.vsts-agent'
+
+default['vsts_agent']['deployment_target'] = false
+default['vsts_agent']['deployment_pool'] = "American Hanko's Deployment Targets"
+default['vsts_agent']['project'] = 'American Hanko'
+default['vsts_agent']['work'] = '_work'

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -44,6 +44,9 @@ module VstsAgentMacOS
           VSTS_AGENT_INPUT_TOKEN: agent_data[:personal_access_token],
           VSTS_AGENT_INPUT_POOL: Chef.node['vsts_agent']['agent_pool'],
           VSTS_AGENT_INPUT_AGENT: Chef.node['vsts_agent']['agent_name'],
+          VSTS_AGENT_INPUT_DEPLOYMENTGROUPNAME: Chef.node['vsts_agent']['deployment_pool'],
+          VSTS_AGENT_INPUT_PROJECTNAME: Chef.node['vsts_agent']['project'],
+          VSTS_AGENT_INPUT_WORK: Chef.node['vsts_agent']['work'],
           HOME: admin_home }
       end
 
@@ -66,6 +69,10 @@ module VstsAgentMacOS
         else
           true
         end
+      end
+
+      def configuration_type
+        Chef.node['vsts_agent']['deployment_target'] ? '--deploymentgroup' : ''
       end
 
       def user_group

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eric.hanko1@gmail.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring a VSTS build/release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.8'
+version '1.3.0'
 chef_version '>= 13.0' if respond_to?(:chef_version)
 
 source_url 'https://github.com/americanhanko/vsts-agent-macos-cookbook'

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -60,7 +60,7 @@ end
 execute 'bootstrap the agent' do
   cwd Agent.agent_home
   user Agent.admin_user
-  command ['./bin/Agent.Listener', 'configure', '--unattended', '--acceptTeeEula']
+  command ['./bin/Agent.Listener', 'configure', Agent.configuration_type, '--unattended', '--acceptTeeEula']
   environment lazy { Agent.vsts_environment }
   not_if { Agent.credentials? }
   live_stream true
@@ -80,7 +80,7 @@ end
 execute 'configure replacement agent' do
   cwd Agent.agent_home
   user Agent.admin_user
-  command ['./bin/Agent.Listener', 'configure', '--replace', '--unattended', '--acceptTeeEula']
+  command ['./bin/Agent.Listener', 'configure', Agent.configuration_type, '--replace', '--unattended', '--acceptTeeEula']
   environment lazy { Agent.vsts_environment }
   live_stream true
   action :nothing


### PR DESCRIPTION
## This PR

Adds the ability to create a VSTS agent of the deployment target/release agent type. This type of agent is used when releasing an artifact in a release definition. By default, the cookbook still bootstraps the target machine as a build agent, but you can change it to be a deployment target by setting the `default['vsts_agent']['deployment_target']` attribute to `true`.