### PR TITLE
Prevent Chef run from killing VSTS worker processs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 provisioner:
   product_name: chef
-  install_strategy: always
+  install_strategy: once
   multiple_converge: 2
   enforce_idempotency: true
 

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -105,12 +105,14 @@ module VstsAgentMacOS
       end
 
       def launchd_service
+        return nil unless launchd_list_output.any? { |label| label.include? agent_name }
         line = launchd_list_output.select { |label| label.include? agent_name }[0]
         entry = line.strip.split(/\t/)
         { 'pid' => entry[0], 'exit_status' => entry[1], 'name' => entry[2] }
       end
 
       def pid
+        return nil if launchd_service.nil?
         return nil unless launchd_service['pid'].integer?
         launchd_service['pid']
       end

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -106,9 +106,10 @@ module VstsAgentMacOS
 
       def worker_running?
         require 'sys/proctable'
-
-        Sys::ProcTable.ps.any? { |p| p.cmdline.match? /Agent\.Worker/ }
-      end
+        Sys::ProcTable.ps.any? do |p|
+          next if p.cmdline.nil?
+          p.cmdline.match? /Agent\.Worker/
+        end
       end
     end
   end

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -100,10 +100,6 @@ module VstsAgentMacOS
         Chef.node['vsts_agent']['admin_user']
       end
 
-      def launchd_list_output
-        shell_out('launchctl list').stdout.lines
-      end
-
       def worker_running?
         require 'sys/proctable'
         Sys::ProcTable.ps.any? do |p|

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -99,7 +99,28 @@ module VstsAgentMacOS
       def admin_user
         Chef.node['vsts_agent']['admin_user']
       end
+
+      def launchd_list_output
+        shell_out('launchctl list').stdout.lines
+      end
+
+      def launchd_service
+        line = launchd_list_output.select { |label| label.include? agent_name }[0]
+        entry = line.strip.split(/\t/)
+        { 'pid' => entry[0], 'exit_status' => entry[1], 'name' => entry[2] }
+      end
+
+      def pid
+        return nil unless launchd_service['pid'].integer?
+        launchd_service['pid']
+      end
     end
+  end
+end
+
+class String
+  def integer?
+    to_i.to_s == self
   end
 end
 

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -111,11 +111,5 @@ module VstsAgentMacOS
   end
 end
 
-class String
-  def integer?
-    to_i.to_s == self
-  end
-end
-
 Chef::Resource.include(VstsAgentMacOS)
 Chef::Recipe.include(VstsAgentMacOS)

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -104,9 +104,15 @@ module VstsAgentMacOS
         shell_out('launchctl list').stdout.lines
       end
 
+      def worker_running?
+        require 'sys/proctable'
+
+        Sys::ProcTable.ps.any? { |p| p.cmdline.match? /Agent\.Worker/ }
+      end
+
       def launchd_service
-        return nil unless launchd_list_output.any? { |label| label.include? agent_name }
-        line = launchd_list_output.select { |label| label.include? agent_name }[0]
+        return nil unless launchd_list_output.any? { |label| label.include? service_name }
+        line = launchd_list_output.select { |label| label.include? service_name }[0]
         entry = line.strip.split(/\t/)
         { 'pid' => entry[0], 'exit_status' => entry[1], 'name' => entry[2] }
       end

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -109,18 +109,6 @@ module VstsAgentMacOS
 
         Sys::ProcTable.ps.any? { |p| p.cmdline.match? /Agent\.Worker/ }
       end
-
-      def launchd_service
-        return nil unless launchd_list_output.any? { |label| label.include? service_name }
-        line = launchd_list_output.select { |label| label.include? service_name }[0]
-        entry = line.strip.split(/\t/)
-        { 'pid' => entry[0], 'exit_status' => entry[1], 'name' => entry[2] }
-      end
-
-      def pid
-        return nil if launchd_service.nil?
-        return nil unless launchd_service['pid'].integer?
-        launchd_service['pid']
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '2.0.1'
+version '2.1.0'
 
 supports 'mac_os_x'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '2.0.1'
+version '3.0.0'
 
 supports 'mac_os_x'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.0'
+version '2.0.1'
 
 supports 'mac_os_x'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '2.0.0'
+version '2.0.1'
 
 supports 'mac_os_x'
 

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -53,7 +53,7 @@ template 'create environment file' do
   group Agent.user_group
   mode 0o644
   cookbook 'vsts_agent_macos'
-  notifies :restart, 'macosx_service[vsts agent launch agent]'
+  notifies :restart, 'macosx_service[start vsts agent launch agent]'
 end
 
 execute 'bootstrap the agent' do
@@ -109,14 +109,14 @@ launchd 'create launchd service plist' do
   action :create
 end
 
-macosx_service 'vsts agent launch agent' do
+macosx_service 'enable vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :enable
   only_if { Agent.launchd_service.nil? }
 end
 
-macosx_service 'vsts agent launch agent' do
+macosx_service 'start vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :start

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -107,7 +107,7 @@ launchd 'create launchd service plist' do
   standard_error_path ::File.join Agent.service_log_path, 'stderr.log'
   environment_variables VSTS_AGENT_SVC: '1'
   session_type 'user'
-  action [:create, :enable]
+  action :create
 end
 
 macosx_service 'vsts agent launch agent' do

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -88,6 +88,8 @@ execute 'configure replacement agent' do
   environment lazy { Agent.vsts_environment }
   live_stream true
   action :nothing
+  notifies :restart, 'macosx_service[start vsts agent launch agent]'
+  not_if { Agent.worker_running? }
 end
 
 file 'create agent service file' do

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -58,6 +58,7 @@ template 'create environment file' do
   mode 0o644
   cookbook 'vsts_agent_macos'
   notifies :restart, 'macosx_service[start vsts agent launch agent]'
+  not_if { Agent.worker_running? }
 end
 
 execute 'bootstrap the agent' do
@@ -111,7 +112,7 @@ launchd 'create launchd service plist' do
   environment_variables VSTS_AGENT_SVC: '1'
   session_type 'user'
   action :create
-  # not_if { Agent.worker_running? }
+  not_if { Agent.worker_running? }
 end
 
 macosx_service 'enable vsts agent launch agent' do

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -83,7 +83,6 @@ execute 'configure replacement agent' do
   environment lazy { Agent.vsts_environment }
   live_stream true
   action :nothing
-  notifies :restart, 'macosx_service[vsts agent launch agent]'
 end
 
 file 'create agent service file' do

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -113,6 +113,13 @@ end
 macosx_service 'vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
-  action [:enable, :start]
+  action :enable
+  only_if { Agent.launchd_service.nil? }
+end
+
+macosx_service 'vsts agent launch agent' do
+  service_name Agent.service_name
+  plist Agent.launchd_plist
+  action :start
   only_if { Agent.pid.nil? }
 end

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -114,4 +114,5 @@ macosx_service 'vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action [:enable, :start]
+  only_if { Agent.pid.nil? }
 end

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -118,12 +118,10 @@ macosx_service 'enable vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :enable
-  # only_if { Agent.launchd_service.nil? }
 end
 
 macosx_service 'start vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :start
-  # only_if { Agent.pid.nil? }
 end

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -1,6 +1,10 @@
 package 'git'
 package 'openssl'
 
+chef_gem 'sys-proctable' do
+  compile_time true
+end
+
 directory '/usr/local/lib/' do
   recursive true
   owner Agent.admin_user
@@ -107,18 +111,19 @@ launchd 'create launchd service plist' do
   environment_variables VSTS_AGENT_SVC: '1'
   session_type 'user'
   action :create
+  # not_if { Agent.worker_running? }
 end
 
 macosx_service 'enable vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :enable
-  only_if { Agent.launchd_service.nil? }
+  # only_if { Agent.launchd_service.nil? }
 end
 
 macosx_service 'start vsts agent launch agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action :start
-  only_if { Agent.pid.nil? }
+  # only_if { Agent.pid.nil? }
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,12 +4,10 @@ require_relative '../../../libraries/agent'
 
 include VstsAgentMacOS
 
-at_exit { ChefSpec::Coverage.report! }
-
 RSpec.configure do |config|
   config.color = true
   config.formatter = :documentation
-  config.log_level = :trace
+end
 end
 
 shared_context 'when converging the recipe' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,31 +9,6 @@ RSpec.configure do |config|
   config.formatter = :documentation
 end
 
-shared_context 'with the VSTS launchd process listed and running' do
-  before do
-    allow(Agent).to receive(:launchd_list_output).and_return(["PID\tStatus\tLabel\n",
-                                                              "240\t0\tcom.apple.trustd.agent\n",
-                                                              "-\t0\tcom.apple.MailServiceAgent\n",
-                                                              "-\t0\tcom.apple.mdworker.mail\n",
-                                                              "-\t0\tcom.apple.mdworker.single.02000000-0000-0000-0000-000000000000\n",
-                                                              "260\t0\tcom.apple.Finder\n",
-                                                              "-\t0\tcom.apple.PackageKit.InstallStatus\n",
-                                                              "19900\t0\tcom.microsoft.vsts-agent\n",
-                                                              "365\t0\tcom.apple.iconservices.iconservicesagent\n",
-                                                              "303\t0\tcom.apple.ContactsAgent\n",
-                                                              "-\t0\tcom.apple.ManagedClientAgent.agent\n",
-                                                              "-\t0\tcom.apple.screensharing.agent\n"])
-  end
-  shared_examples 'not affecting the VSTS agent process' do
-    it { is_expected.to_not start_macosx_service('vsts agent launch agent') }
-    it { is_expected.to_not enable_macosx_service('vsts agent launch agent') }
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
-end
-
 shared_context 'with the VSTS Agent.Worker process running' do
   before do
     allow(Agent).to receive(:worker_running?).and_return(true)
@@ -42,58 +17,6 @@ shared_context 'with the VSTS Agent.Worker process running' do
     it { is_expected.to_not create_launchd('create launchd service plist') }
     it { is_expected.to_not start_macosx_service('vsts agent launch agent') }
     it { is_expected.to_not enable_macosx_service('vsts agent launch agent') }
-  end
-end
-
-shared_context 'with the VSTS launchd process listed but not running' do
-  before do
-    allow(Agent).to receive(:launchd_list_output).and_return(["PID\tStatus\tLabel\n",
-                                                              "240\t0\tcom.apple.trustd.agent\n",
-                                                              "-\t0\tcom.apple.MailServiceAgent\n",
-                                                              "-\t0\tcom.apple.mdworker.mail\n",
-                                                              "-\t0\tcom.apple.mdworker.single.02000000-0000-0000-0000-000000000000\n",
-                                                              "260\t0\tcom.apple.Finder\n",
-                                                              "-\t0\tcom.apple.PackageKit.InstallStatus\n",
-                                                              "-\t0\tcom.microsoft.vsts-agent\n",
-                                                              "365\t0\tcom.apple.iconservices.iconservicesagent\n",
-                                                              "303\t0\tcom.apple.ContactsAgent\n",
-                                                              "-\t0\tcom.apple.ManagedClientAgent.agent\n",
-                                                              "-\t0\tcom.apple.screensharing.agent\n"])
-  end
-  shared_examples 'starting but not enabling the VSTS agent process' do
-    it { is_expected.to start_macosx_service('vsts agent launch agent') }
-    it { is_expected.to_not enable_macosx_service('vsts agent launch agent') }
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
-end
-
-shared_context 'with the VSTS launchd process not listed and not running' do
-  before do
-    allow(Agent).to receive(:launchd_list_output).and_return(["PID\tStatus\tLabel\n",
-                                                              "-\t0\tcom.google.Chrome.22128\n",
-                                                              "772\t0\tcom.google.Chrome.18908\n",
-                                                              "-\t0\tcom.apple.SafariHistoryServiceAgent\n",
-                                                              "502\t0\tcom.apple.Finder\n",
-                                                              "554\t0\tcom.apple.homed\n",
-                                                              "651\t0\tcom.apple.SafeEjectGPUAgent\n",
-                                                              "-\t0\tcom.apple.quicklook\n",
-                                                              "-\t0\tcom.apple.parentalcontrols.check\n",
-                                                              "-\t0\tcom.apple.PackageKit.InstallStatus\n",
-                                                              "555\t0\tcom.apple.mediaremoteagent\n",
-                                                              "-\t0\tcom.apple.FontWorker\n",
-                                                              "521\t0\tcom.apple.bird\n"])
-  end
-
-  shared_examples 'starting and enabling the VSTS agent process' do
-    it { is_expected.to start_macosx_service('vsts agent launch agent') }
-    it { is_expected.to enable_macosx_service('vsts agent launch agent') }
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
   end
 end
 
@@ -106,23 +29,8 @@ describe 'vsts_agent_macos::bootstrap' do
     allow(Chef::DataBagItem).to receive(:load).with('vsts', 'build_agent').and_return(personal_access_token: 'p9817234jhbasdfo87q234bnsadfasdf234')
   end
 
-  describe 'VSTS launchd process already listed and running' do
-    include_context 'with the VSTS launchd process listed and running'
-    it_behaves_like 'not affecting the VSTS agent process'
-  end
-
   describe 'VSTS Agent.Worker process running' do
     include_context 'with the VSTS Agent.Worker process running'
     it_behaves_like 'not affecting the VSTS Agent.Worker process or the launch agent'
   end
-
-  # describe 'VSTS launchd process listed but not currently running' do
-  #   include_context 'with the VSTS launchd process listed but not running'
-  #   it_behaves_like 'starting but not enabling the VSTS agent process'
-  # end
-
-  # describe 'VSTS launchd process not listed and presumed not running' do
-  #   include_context 'with the VSTS launchd process not listed and not running'
-  #   it_behaves_like 'starting and enabling the VSTS agent process'
-  # end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,6 +34,17 @@ shared_context 'with the VSTS launchd process listed and running' do
   end
 end
 
+shared_context 'with the VSTS Agent.Worker process running' do
+  before do
+    allow(Agent).to receive(:worker_running?).and_return(true)
+  end
+  shared_examples 'not affecting the VSTS Agent.Worker process or the launch agent' do
+    it { is_expected.to_not create_launchd('create launchd service plist') }
+    it { is_expected.to_not start_macosx_service('vsts agent launch agent') }
+    it { is_expected.to_not enable_macosx_service('vsts agent launch agent') }
+  end
+end
+
 shared_context 'with the VSTS launchd process listed but not running' do
   before do
     allow(Agent).to receive(:launchd_list_output).and_return(["PID\tStatus\tLabel\n",
@@ -100,13 +111,18 @@ describe 'vsts_agent_macos::bootstrap' do
     it_behaves_like 'not affecting the VSTS agent process'
   end
 
-  describe 'VSTS launchd process listed but not currently running' do
-    include_context 'with the VSTS launchd process listed but not running'
-    it_behaves_like 'starting but not enabling the VSTS agent process'
+  describe 'VSTS Agent.Worker process running' do
+    include_context 'with the VSTS Agent.Worker process running'
+    it_behaves_like 'not affecting the VSTS Agent.Worker process or the launch agent'
   end
 
-  describe 'VSTS launchd process not listed and presumed not running' do
-    include_context 'with the VSTS launchd process not listed and not running'
-    it_behaves_like 'starting and enabling the VSTS agent process'
-  end
+  # describe 'VSTS launchd process listed but not currently running' do
+  #   include_context 'with the VSTS launchd process listed but not running'
+  #   it_behaves_like 'starting but not enabling the VSTS agent process'
+  # end
+
+  # describe 'VSTS launchd process not listed and presumed not running' do
+  #   include_context 'with the VSTS launchd process not listed and not running'
+  #   it_behaves_like 'starting and enabling the VSTS agent process'
+  # end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -21,9 +21,9 @@ shared_context 'when converging the recipe' do
 end
 
 describe 'vsts_agent_macos::bootstrap' do
-  let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(node_attributes)
-    runner.converge(described_recipe)
+  platform 'mac_os_x', '10.14'
+  default_attributes['homebrew']['enable-analytics'] = false
+  default_attributes['vsts_agent']['agent_name'] = 'com.microsoft.vsts-agent'
   end
 
   before do


### PR DESCRIPTION
This PR prevents the chef-client from restarting the VSTS worker process if a job is currently running on the node. 

It requires the use of the `sys/proctable` gem to look for the running VSTS worker process and guard against any in-run restarts. 

