### PR TITLE
Update agent_pool attribute for build_agent suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,7 +40,7 @@ suites:
   - recipe[vsts_agent_macos::default]
   attributes:
     vsts_agent:
-      agent_pool: OXO Hub Eng Mac Pool
+      agent_pool: SEAL Mac Staging
       account: office
       data_bag: vsts
       data_bag_item: office_build_agent


### PR DESCRIPTION
### This PR
- Updates the `agent_pool` attribute in the `build_agent` kitchen test suite.

### Why
The builds are failing when trying to use the old agent_pool due to the updated PAT token.