### PR TITLE
Rename to Azure Pipelines Agent

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,10 +1,23 @@
 ---
 provisioner:
+  channel: stable
   data_bags_path: data_bags
   enforce_idempotency: true
   install_strategy: once
+  max_retries: 3
   multiple_converge: 2
   product_name: chef
+  product_version: latest
+  attributes:
+    azure_pipelines_agent:
+      account: office
+      data_bag: azure_pipelines
+      data_bag_item: office_build_agent
+      additional_environment:
+        VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
+    homebrew:
+      auto-update: false
+      owner: vagrant
 
 platforms:
 - name: high-sierra
@@ -39,14 +52,6 @@ suites:
   attributes:
     azure_pipelines_agent:
       agent_pool: SEAL Mac Staging
-      account: office
-      data_bag: azure_pipelines
-      data_bag_item: office_build_agent
-      additional_environment:
-        VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
-    homebrew:
-      auto-update: false
-      owner: vagrant
 
 - name: deployment_group
   run_list:
@@ -55,13 +60,5 @@ suites:
     azure_pipelines_agent:
       deployment_group: Cookbook Group
       deployment_group_tags: test,kitchen,vagrant,chef
-      account: office
-      data_bag: azure_pipelines
-      data_bag_item: office_build_agent
       project: APEX
       work: _work
-      additional_environment:
-        VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
-    homebrew:
-      auto-update: false
-      owner: vagrant

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,6 @@ platforms:
     box: microsoft/macos-high-sierra
     box_check_update: true
     box_url: http://office-infra-boxes.corp.microsoft.com:8099/microsoft/macos-high-sierra
-    box_version: 10.13.6.pre.v4
     name: vagrant
     provider: parallels
 
@@ -21,7 +20,6 @@ platforms:
     box: microsoft/macos-mojave
     box_check_update: true
     box_url: http://office-infra-boxes.corp.microsoft.com:8099/microsoft/macos-mojave
-    box_version: 10.14.2
     name: vagrant
     provider: parallels
 
@@ -37,12 +35,12 @@ verifier:
 suites:
 - name: build_agent
   run_list:
-  - recipe[vsts_agent_macos::default]
+  - recipe[azure_pipelines_agent_macos::default]
   attributes:
-    vsts_agent:
+    azure_pipelines_agent:
       agent_pool: SEAL Mac Staging
       account: office
-      data_bag: vsts
+      data_bag: azure_pipelines
       data_bag_item: office_build_agent
       additional_environment:
         VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
@@ -52,13 +50,13 @@ suites:
 
 - name: deployment_group
   run_list:
-  - recipe[vsts_agent_macos::default]
+  - recipe[azure_pipelines_agent_macos::default]
   attributes:
-    vsts_agent:
+    azure_pipelines_agent:
       deployment_group: Cookbook Group
       deployment_group_tags: test,kitchen,vagrant,chef
       account: office
-      data_bag: vsts
+      data_bag: azure_pipelines
       data_bag_item: office_build_agent
       project: APEX
       work: _work

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,9 @@
 ---
+driver:
+  name: vagrant
+  provider: parallels
+  box_check_update: true
+
 provisioner:
   client_rb:
     chef_license: accept
@@ -16,53 +21,43 @@ provisioner:
       account: office
       data_bag: azure_pipelines
       data_bag_item: office_build_agent
-      additional_environment:
-        VAGRANT_SERVER_URL: http://office-infra-boxes.corp.microsoft.com
     homebrew:
       auto-update: false
       owner: vagrant
-
-platforms:
-- name: high-sierra
-  driver:
-    box: microsoft/macos-high-sierra
-    box_check_update: true
-    box_url: http://office-infra-boxes.corp.microsoft.com:8099/microsoft/macos-high-sierra
-    name: vagrant
-    provider: parallels
-
-- name: mojave
-  driver:
-    box: microsoft/macos-mojave
-    box_check_update: true
-    box_url: http://office-infra-boxes.corp.microsoft.com:8099/microsoft/macos-mojave
-    name: vagrant
-    provider: parallels
 
 verifier:
   chef_license: accept
   name: inspec
   format:
-  - cli
-  - junit:/tmp/inspec.xml
+    - cli
+    - junit:/tmp/inspec.xml
   sudo: false
   inspec_tests:
-  - test/integration/default
+    - test/integration/default
+
+platforms:
+  - name: high-sierra
+    driver:
+      box: microsoft/macos-high-sierra
+
+  - name: mojave
+    driver:
+      box: microsoft/macos-mojave
 
 suites:
-- name: build_agent
-  run_list:
-  - recipe[azure_pipelines_agent_macos::default]
-  attributes:
-    azure_pipelines_agent:
-      agent_pool: SEAL Mac Staging
+  - name: build_agent
+    run_list:
+      - recipe[azure_pipelines_agent_macos::default]
+    attributes:
+      azure_pipelines_agent:
+        agent_pool: SEAL Mac Staging
 
-- name: deployment_group
-  run_list:
-  - recipe[azure_pipelines_agent_macos::default]
-  attributes:
-    azure_pipelines_agent:
-      deployment_group: Cookbook Group
-      deployment_group_tags: test,kitchen,vagrant,chef
-      project: APEX
-      work: _work
+  - name: deployment_group
+    run_list:
+      - recipe[azure_pipelines_agent_macos::default]
+    attributes:
+      azure_pipelines_agent:
+        deployment_group: Cookbook Group
+        deployment_group_tags: test,kitchen,vagrant,chef
+        project: APEX
+        work: _work

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Eric Hanko, 2017-2018
+Copyright (c) Eric Hanko, 2017-2019
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Azure DevOps Build and Release Agent Cookbook for macOS
 =======================================================
 
-![](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2373/badge)
+[![Build status](https://dev.azure.com/office/APEX/_apis/build/status/Apple%20Lab/cookbooks/azure_pipelines_agent_macos)](https://dev.azure.com/office/APEX/_build/latest?definitionId=2373)
 
 [Visual Studio Team Services is now Azure DevOps Services](https://docs.microsoft.com/en-us/azure/devops/user-guide/what-happened-vsts)
 We're working on the best way to rename the cookbook and recipes while maintaining backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ default['azure_piplines_agent']['agent_name']
 
 The version of the agent to install.
 
-**Default value:** `'2.144.0'`
+**Default value:** `'2.150.3'`
 
 ```ruby
 default['azure_piplines_agent']['version']
@@ -56,7 +56,7 @@ default['azure_piplines_agent']['agent_pool']
 
 ### Organization Name
 
-The name of your Azure DevOps organization. (i.e. 'americanhanko' in `https://dev.azure.com/americanhanko`)
+The name of your Azure DevOps organization. (e.g. 'americanhanko' in `https://dev.azure.com/americanhanko`)
 
 **Default value:** `americanhanko`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Azure DevOps Build and Release Agent Cookbook for macOS
 
 ![](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2373/badge)
 
-[Visual Studio Team Services is now Azure DevOps Services](https://docs.microsoft.com/en-us/azure/devops/user-guide/what-happened-vsts?view=vsts)
+[Visual Studio Team Services is now Azure DevOps Services](https://docs.microsoft.com/en-us/azure/devops/user-guide/what-happened-vsts)
 We're working on the best way to rename the cookbook and recipes while maintaining backwards compatibility.
 
 Recipes
@@ -11,13 +11,13 @@ Recipes
 
 ### Bootstrap
 
-Usage: `vsts_agent_macos::bootstrap`
+Usage: `azure_piplines_agent_macos::bootstrap`
 
 Add the node to the agent pool or deployment group.
 
 ### Teardown
 
-Usage: `vsts_agent_macos::teardown`
+Usage: `azure_piplines_agent_macos::teardown`
 
 Remove an existing agent from the build pool or deployment group.
 
@@ -31,7 +31,7 @@ The name of the agent.
 **Default value:** `node['hostname']`
 
 ```ruby
-default['vsts_agent']['agent_name']
+default['azure_piplines_agent']['agent_name']
 ```
 
 ### Agent Version
@@ -41,7 +41,7 @@ The version of the agent to install.
 **Default value:** `'2.144.0'`
 
 ```ruby
-default['vsts_agent']['version']
+default['azure_piplines_agent']['version']
 ```
 
 ### Agent Pool
@@ -51,7 +51,7 @@ The name of the agent pool you wish to add the agent to.
 **Default value:** `American Hanko's Agents`
 
 ```ruby
-default['vsts_agent']['agent_pool']
+default['azure_piplines_agent']['agent_pool']
 ```
 
 ### Organization Name
@@ -61,7 +61,7 @@ The name of your Azure DevOps organization. (i.e. 'americanhanko' in `https://de
 **Default value:** `americanhanko`
 
 ```ruby
-default['vsts_agent']['account']
+default['azure_piplines_agent']['account']
 ```
 
 ### Admin User
@@ -71,17 +71,17 @@ The username of an adminstrator on the macOS system.
 **Default value:** `'vagrant'`
 
 ```ruby
-default['vsts_agent']['admin_user']
+default['azure_piplines_agent']['admin_user']
 ```
 
 ### Agent Home Directory
 
 The location that contains all builds, source, release, etc.
 
-**Default value:** `'/Users/#{node['vsts_agent']['admin_user']}/vsts-agent'`
+**Default value:** `'/Users/#{node['azure_piplines_agent']['admin_user']}/azure-piplines-agent'`
 
 ```ruby
-default['vsts_agent']['agent_home']
+default['azure_piplines_agent']['agent_home']
 ```
 
 ### Additional Environment Variables
@@ -93,31 +93,31 @@ report back to the servers.
 **Default value:** `{}`
 
 ```ruby
-default['vsts_agent']['additional_environment']
+default['azure_piplines_agent']['additional_environment']
 ```
 
 Deployment Group
 ----------------
 
 This cookbook supports adding agents to Azure DevOps deployment groups. To use this feature, simply
-set the `default['vsts_agent']['deployment_group']` attribute. In addition, make sure you have
+set the `default['azure_piplines_agent']['deployment_group']` attribute. In addition, make sure you have
 the appropriate values set for the following attributes shown below. By default, we assume that
-if the `default['vsts_agent']['deployment_group']` attribute is `nil`, we are bootstrapping
+if the `default['azure_piplines_agent']['deployment_group']` attribute is `nil`, we are bootstrapping
 a build agent and _not_ a deployment agent. This means if you set this attribute, it will
 override the default functionality. You may optionally specifiy deployment group tags using
-`default['vsts_agent']['deployment_group_tags']`.
+`default['azure_piplines_agent']['deployment_group_tags']`.
 
 ```ruby
-default['vsts_agent']['deployment_group'] = nil
-default['vsts_agent']['project'] = nil
-default['vsts_agent']['work'] = nil
-default['vsts_agent']['deployment_group_tags'] = nil
+default['azure_piplines_agent']['deployment_group'] = nil
+default['azure_piplines_agent']['project'] = nil
+default['azure_piplines_agent']['work'] = nil
+default['azure_piplines_agent']['deployment_group_tags'] = nil
 ```
 
 Authentication
 --------------
 
-This cookbook uses a [personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts)
+This cookbook uses a [personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
 to authenticate to your organization on the Azure DevOps servers. The cookbook allows access to the token via either an attribute, within a data bag or using a chef vault item.
 
 ### Plaintext Attribute
@@ -125,7 +125,7 @@ to authenticate to your organization on the Azure DevOps servers. The cookbook a
 Example:
 
 ```ruby
-default['vsts_agent']['pat'] = '0fbdebc988934add98179ddaae019a01711'
+default['azure_piplines_agent']['pat'] = '0fbdebc988934add98179ddaae019a01711'
 ```
 
 ### Data Bag or Chef Vault Item
@@ -137,20 +137,20 @@ accordingly:
 Example:
 
 ```ruby
-default['vsts_agent']['data_bag'] = 'tea_bag'
-default['vsts_agent']['data_bag_item'] = 'green_tea'
+default['azure_piplines_agent']['data_bag'] = 'tea_bag'
+default['azure_piplines_agent']['data_bag_item'] = 'green_tea'
 ```
 
 However, it **must** contain a `personal_access_token` key with
 the token itself as the value. The token must have rights to read and modify
 build agents. The permissions are selected at the time of the PAT creation, which
-you can read more about [here](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts).
+you can read more about [here](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate).
 
 Example:
 
 ```json
 {
-  "id": "vsts_build_agent",
+  "id": "azure_piplines_build_agent",
   "personal_access_token": "iu8tfaxxrhce7yeu434yo9zfjtxif3jygzk24wegi855er2moobs"
 }
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,6 @@ default['azure_pipelines_agent']['additional_environment'] = {}
 default['azure_pipelines_agent']['service_name'] = 'com.microsoft.azure-pipelines-agent'
 
 default['azure_pipelines_agent']['deployment_group'] = nil
-
 default['azure_pipelines_agent']['deployment_group_tags'] = nil
 default['azure_pipelines_agent']['project'] = nil
 default['azure_pipelines_agent']['work'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,20 +1,20 @@
-default['vsts_agent']['admin_user'] = 'vagrant'
-default['vsts_agent']['user_group'] = 'staff'
+default['azure_pipelines_agent']['admin_user'] = 'vagrant'
+default['azure_pipelines_agent']['user_group'] = 'staff'
 
-default['vsts_agent']['pat'] = nil
-default['vsts_agent']['data_bag'] = 'vsts'
-default['vsts_agent']['data_bag_item'] = 'build_agent'
+default['azure_pipelines_agent']['pat'] = nil
+default['azure_pipelines_agent']['data_bag'] = 'azure_pipelines'
+default['azure_pipelines_agent']['data_bag_item'] = 'build_agent'
 
-default['vsts_agent']['agent_name'] = node['hostname']
-default['vsts_agent']['account'] = 'americanhanko'
-default['vsts_agent']['agent_pool'] = "American Hanko's Build Agents"
+default['azure_pipelines_agent']['agent_name'] = node['hostname']
+default['azure_pipelines_agent']['account'] = nil
+default['azure_pipelines_agent']['agent_pool'] = nil
 
-default['vsts_agent']['version'] = '2.144.0'
-default['vsts_agent']['additional_environment'] = {}
-default['vsts_agent']['service_name'] = 'com.microsoft.vsts-agent'
+default['azure_pipelines_agent']['version'] = '2.150.3'
+default['azure_pipelines_agent']['additional_environment'] = {}
+default['azure_pipelines_agent']['service_name'] = 'com.microsoft.azure-pipelines-agent'
 
-default['vsts_agent']['deployment_group'] = nil
+default['azure_pipelines_agent']['deployment_group'] = nil
 
-default['vsts_agent']['deployment_group_tags'] = nil
-default['vsts_agent']['project'] = nil
-default['vsts_agent']['work'] = nil
+default['azure_pipelines_agent']['deployment_group_tags'] = nil
+default['azure_pipelines_agent']['project'] = nil
+default['azure_pipelines_agent']['work'] = nil

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -26,10 +26,6 @@ module AzurePipelines
         ::File.join '/', 'Users', admin_user
       end
 
-      def account_url
-        ::File.join 'https://dev.azure.com', account_name
-      end
-
       def environment
         default_environment.merge additional_environment
       end
@@ -39,14 +35,17 @@ module AzurePipelines
       end
 
       def default_environment
-        { VSTS_AGENT_INPUT_URL: account_url,
-          VSTS_AGENT_INPUT_POOL: agent_attrs['agent_pool'],
+        account_url = ::File.join 'https://dev.azure.com', agent_attrs['account']
+        {
+          HOME: admin_home,
           VSTS_AGENT_INPUT_AGENT: agent_attrs['agent_name'],
           VSTS_AGENT_INPUT_DEPLOYMENTGROUPNAME: agent_attrs['deployment_group'],
           VSTS_AGENT_INPUT_DEPLOYMENTGROUPTAGS: agent_attrs['deployment_group_tags'],
+          VSTS_AGENT_INPUT_POOL: agent_attrs['agent_pool'],
           VSTS_AGENT_INPUT_PROJECTNAME: agent_attrs['project'],
+          VSTS_AGENT_INPUT_URL: account_url,
           VSTS_AGENT_INPUT_WORK: agent_attrs['work'],
-          HOME: admin_home }
+        }
       end
 
       def launchd_plist
@@ -84,10 +83,6 @@ module AzurePipelines
 
       def agent_name
         agent_attrs['agent_name']
-      end
-
-      def account_name
-        agent_attrs['account']
       end
 
       def admin_user

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,17 +1,17 @@
-name 'vsts_agent_macos'
+name 'azure_pipelines_agent_macos'
 maintainer 'Eric Hanko'
 maintainer_email 'eric.hanko1@gmail.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '2.1.2'
+version '3.0.0'
 
 supports 'mac_os_x'
 
-source_url 'https://github.com/americanhanko/vsts-agent-macos-cookbook'
-issues_url 'https://github.com/americanhanko/vsts-agent-macos-cookbook/issues'
+source_url 'https://github.com/americanhanko/azure-pipelines-agent-macos-cookbook'
+issues_url 'https://github.com/americanhanko/azure-pipelines-agent-macos-cookbook/issues'
 
-depends 'chef-vault', '~> 3.1.1'
+depends 'chef-vault', '~> 3.0.0'
 depends 'homebrew', '~> 5.0.0'
-depends 'tar', '~> 2.1.0'
+depends 'tar', '~> 2.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,2 +1,2 @@
 include_recipe 'homebrew::default'
-include_recipe 'vsts_agent_macos::bootstrap'
+include_recipe '::bootstrap'

--- a/recipes/teardown.rb
+++ b/recipes/teardown.rb
@@ -1,15 +1,15 @@
-vsts_attrs = node['vsts_agent']
+agent_attrs = node['azure_pipelines_agent']
 
-if vsts_attrs['pat']
-  pat = vsts_attrs['pat']
+if agent_attrs['pat']
+  pat = agent_attrs['pat']
 else
-  auth_data = chef_vault_item vsts_attrs['data_bag'], vsts_attrs['data_bag_item']
+  auth_data = chef_vault_item agent_attrs['data_bag'], agent_attrs['data_bag_item']
   pat = auth_data['personal_access_token']
 end
 
 auth_params = ['--auth', 'pat', '--token', pat]
 
-macosx_service 'vsts-agent' do
+macosx_service 'azure-pipelines-agent' do
   service_name Agent.service_name
   plist Agent.launchd_plist
   action [:disable, :stop]
@@ -31,7 +31,7 @@ execute 'remove agent' do
   cwd Agent.agent_home
   user Agent.admin_user
   command ['./bin/Agent.Listener', 'remove', *auth_params]
-  environment lazy { Agent.vsts_environment }
+  environment lazy { Agent.environment }
   live_stream true
   action :nothing
   subscribes :run, 'file[service name reference file]'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,7 +4,7 @@ require 'chef-vault/test_fixtures'
 
 require_relative '../../../libraries/agent'
 
-include VstsAgentMacOS
+include AzurePipelines
 
 RSpec.configure do |config|
   config.color = true
@@ -16,7 +16,7 @@ shared_context 'agent is running a job' do
   include ChefVault::TestFixtures.rspec_shared_context
 
   before do
-    stub_data_bag_item('vsts', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
+    stub_data_bag_item('azure_pipelines', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
     allow(Agent).to receive(:worker_running?).and_return true
   end
 
@@ -29,17 +29,17 @@ shared_context 'agent is idle' do
   include ChefVault::TestFixtures.rspec_shared_context
 
   before do
-    stub_data_bag_item('vsts', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
+    stub_data_bag_item('azure_pipelines', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
     allow(Agent).to receive(:worker_running?).and_return false
   end
 
   shared_examples 'creating the launch daemon, enabling, and starting the service' do
     it { is_expected.to create_launchd('create launchd service plist') }
-    it { expect(chef_run.template('create environment file')).to notify('macosx_service[vsts-agent]').to(:restart) }
+    it { expect(chef_run.template('create environment file')).to notify('macosx_service[azure-pipelines-agent]').to(:restart) }
   end
 end
 
-describe 'vsts_agent_macos::bootstrap' do
+describe 'azure_pipelines_agent_macos::bootstrap' do
   platform 'mac_os_x', '10.14'
 
   describe 'bootstrap when running a job' do

--- a/templates/env.erb
+++ b/templates/env.erb
@@ -3,6 +3,6 @@ LANG=en_US.UTF-8
 <% attributes.each do |attribute| %>
 <%= attribute.upcase %>=<%= node[attribute] %>
 <% end %>
-<% node['vsts_agent']['additional_environment'].each do |variable, setting| %>
+<% node['azure_pipelines_agent']['additional_environment'].each do |variable, setting| %>
 <%= variable %>=<%= setting %>
 <% end %>

--- a/test/integration/data_bags/azure_pipelines/build_agent.json
+++ b/test/integration/data_bags/azure_pipelines/build_agent.json
@@ -1,4 +1,4 @@
 {
-  "id": "vsts_build_agent",
+  "id": "azure_pipelines_agent",
   "personal_access_token": "iu8tfaxxrhce7yeu434yo9zfjtxif3jygzk24wegi855er2moobs"
 }

--- a/test/integration/data_bags/azure_pipelines/build_agent.json
+++ b/test/integration/data_bags/azure_pipelines/build_agent.json
@@ -1,4 +1,4 @@
 {
-  "id": "azure_pipelines_agent",
+  "id": "azure_pipelines",
   "personal_access_token": "iu8tfaxxrhce7yeu434yo9zfjtxif3jygzk24wegi855er2moobs"
 }

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -34,5 +34,4 @@ describe file('/Users/vagrant/azure-pipelines-agent/.env') do
   it { should exist }
   its('owner') { should eq 'vagrant' }
   its('content') { should match(/^LANG=en_US\.UTF\-8$/) }
-  its('content') { should match %r{^VAGRANT_SERVER_URL=http:\/\/office\-infra\-boxes\.corp\.microsoft\.com$} }
 end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -5,18 +5,18 @@ describe user('vagrant') do
   its('home') { should eq '/Users/vagrant' }
 end
 
-describe launchd_service('com.microsoft.vsts-agent') do
+describe launchd_service('com.microsoft.azure-pipelines-agent') do
   it { should be_enabled }
   it { should be_installed }
   it { should be_running }
 end
 
-describe file('/Users/vagrant/vsts-agent/.credentials') do
+describe file('/Users/vagrant/azure-pipelines-agent/.credentials') do
   it { should exist }
   its('owner') { should eq 'vagrant' }
 end
 
-describe file('/Users/vagrant/vsts-agent/.path') do
+describe file('/Users/vagrant/azure-pipelines-agent/.path') do
   it { should exist }
   its('owner') { should eq 'vagrant' }
   its('content') { should match %r{/usr/local/bin} }
@@ -25,12 +25,12 @@ describe file('/Users/vagrant/vsts-agent/.path') do
   its('content') { should match %r{/usr/sbin} }
 end
 
-describe file('/Users/vagrant/vsts-agent/.agent') do
+describe file('/Users/vagrant/azure-pipelines-agent/.agent') do
   it { should exist }
   its('owner') { should eq 'vagrant' }
 end
 
-describe file('/Users/vagrant/vsts-agent/.env') do
+describe file('/Users/vagrant/azure-pipelines-agent/.env') do
   it { should exist }
   its('owner') { should eq 'vagrant' }
   its('content') { should match(/^LANG=en_US\.UTF\-8$/) }


### PR DESCRIPTION
- Bumps version to 3.0.0
- Updates all interfaces from `vsts` to `azure_pipelines`
- Updates build badge
- Removes some duplication