### PR TITLE
rename kitchen yaml and move chef_license key

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,8 +5,7 @@ driver:
   box_check_update: true
 
 provisioner:
-  client_rb:
-    chef_license: accept
+  chef_license: accept
   channel: stable
   data_bags_path: data_bags
   enforce_idempotency: true


### PR DESCRIPTION
### This PR
- Renames .kitchen.yml to kitchen.yml
- Updates chef_license acceptance key

### Why
We want to align our build definitions internally to look for the same kitchen YAML file and be able to utilize common.yml for builds.