### PR TITLE
Remove chef-vault cookbook dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Eric Hanko, 2017-2019
+Copyright (c) Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,54 @@
+name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - documentation/*
+    - LICENSE
+    - README.md
+    - CHANGELOG.md
+    - TESTING.md
+    - CONTRIBUTING.md
+    - .mailmap
+    - .rubocop.yml
+    - .gitignore
+    - chefignore
+
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - documentation/*
+    - LICENSE
+    - README.md
+    - CHANGELOG.md
+    - TESTING.md
+    - CONTRIBUTING.md
+    - .mailmap
+    - .rubocop.yml
+    - .gitignore
+    - chefignore
+
+resources:
+  repositories:
+  - repository: templates
+    type: git
+    name: chef-pipelines-templates
+
+jobs:
+- template: chefspec-cookstyle-foodcritic.yml@templates
+- template: test-kitchen.yml@templates
+  parameters:
+    platforms:
+    - high-sierra
+    - mojave
+    suites:
+    - build-agent
+    - deployment-group
+    kitchenFile: kitchen.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,17 +1,15 @@
 name 'azure_pipelines_agent_macos'
-maintainer 'Eric Hanko'
-maintainer_email 'eric.hanko1@gmail.com'
+maintainer 'Microsoft'
+maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.2'
+chef_version '>= 14.0'
+version '3.1.0'
 
 supports 'mac_os_x'
 
-source_url 'https://github.com/americanhanko/azure-pipelines-agent-macos-cookbook'
-issues_url 'https://github.com/americanhanko/azure-pipelines-agent-macos-cookbook/issues'
+source_url 'https://github.com/microsoft/azure-pipelines-agent-macos-cookbook'
+issues_url 'https://github.com/microsoft/azure-pipelines-agent-macos-cookbook/issues'
 
-depends 'chef-vault', '~> 3.1.0'
 depends 'homebrew', '~> 5.0.0'
 depends 'tar', '~> 2.0.0'

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -66,7 +66,7 @@ template 'create environment file' do
   source 'env.erb'
   owner Agent.admin_user
   group Agent.user_group
-  mode 0o644
+  mode '644'
   cookbook 'azure_pipelines_agent_macos'
   notifies :restart, 'macosx_service[azure-pipelines-agent]'
   not_if { Agent.worker_running? }

--- a/recipes/bootstrap.rb
+++ b/recipes/bootstrap.rb
@@ -10,7 +10,7 @@ agent_attrs = node['azure_pipelines_agent']
 if agent_attrs['pat']
   pat = agent_attrs['pat']
 else
-  auth_data = chef_vault_item agent_attrs['data_bag'], agent_attrs['data_bag_item']
+  auth_data = data_bag_item agent_attrs['data_bag'], agent_attrs['data_bag_item']
   pat = auth_data['personal_access_token']
 end
 

--- a/recipes/teardown.rb
+++ b/recipes/teardown.rb
@@ -3,7 +3,7 @@ agent_attrs = node['azure_pipelines_agent']
 if agent_attrs['pat']
   pat = agent_attrs['pat']
 else
-  auth_data = chef_vault_item agent_attrs['data_bag'], agent_attrs['data_bag_item']
+  auth_data = data_bag_item agent_attrs['data_bag'], agent_attrs['data_bag_item']
   pat = auth_data['personal_access_token']
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,6 +1,5 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'chef-vault/test_fixtures'
 
 require_relative '../../../libraries/agent'
 
@@ -13,8 +12,6 @@ RSpec.configure do |config|
 end
 
 shared_context 'agent is running a job' do
-  include ChefVault::TestFixtures.rspec_shared_context
-
   before do
     stub_data_bag_item('azure_pipelines', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
     allow(Agent).to receive(:worker_running?).and_return true
@@ -26,8 +23,6 @@ shared_context 'agent is running a job' do
 end
 
 shared_context 'agent is idle' do
-  include ChefVault::TestFixtures.rspec_shared_context
-
   before do
     stub_data_bag_item('azure_pipelines', 'build_agent').and_return('personal_access_token' => 'p9817234jhbasdfo87q234bnsadfasdf234')
     allow(Agent).to receive(:worker_running?).and_return false


### PR DESCRIPTION
### This PR:

- Removes the `chef-vault` cookbook dependency
- Updates metadata and licensing information
- Updates to new cookstyle cops 