### PR TITLE
loosen cookbook dependency pins

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 chef_version '>= 14.0'
-version '3.1.3'
+version '3.1.4'
 
 supports 'mac_os_x'
 
 source_url 'https://github.com/microsoft/azure-pipelines-agent-macos-cookbook'
 issues_url 'https://github.com/microsoft/azure-pipelines-agent-macos-cookbook/issues'
 
-depends 'homebrew', '~> 5.0.0'
-depends 'tar', '~> 2.0.0'
+depends 'homebrew', '~> 5.0'
+depends 'tar', '~> 2.0'


### PR DESCRIPTION
This PR loosens cookbook dependency pins to allow a recent fix from the homebrew cookbook to be consumed: https://github.com/chef-cookbooks/homebrew/issues/145