### PR TITLE
remove URI.encode and replace with CGI.escapeHTML

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,8 +46,7 @@ jobs:
 - template: test-kitchen.yml@templates
   parameters:
     platforms:
-    - high-sierra
-    - mojave
+    - monterey
     suites:
     - build-agent
     - deployment-group

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,5 +49,4 @@ jobs:
     - monterey
     suites:
     - build-agent
-    - deployment-group
     kitchenFile: kitchen.yml

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,8 +18,7 @@ provisioner:
   attributes:
     azure_pipelines_agent:
       account: office
-      data_bag: azure_pipelines
-      data_bag_item: office_build_agent
+      pat: <%= ENV['AGENT_PAT'] %>
     homebrew:
       auto-update: false
       owner: vagrant

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,13 +35,9 @@ verifier:
     - test/integration/default
 
 platforms:
-  - name: high-sierra
+  - name: monterey
     driver:
-      box: microsoft/macos-high-sierra
-
-  - name: mojave
-    driver:
-      box: microsoft/macos-mojave
+      box: microsoft/macos-monterey
 
 suites:
   - name: build_agent

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -7,7 +7,7 @@ module AzurePipelines
     class << self
       def release_download_url(version = nil)
         version ||= agent_attrs['version']
-        ::CGI::Util.escapeHTML("https://vstsagentpackage.azureedge.net/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz")
+        ::CGI.escapeHTML("https://vstsagentpackage.azureedge.net/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz")
       end
 
       def agent_home

--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'cgi/util'
 
 include Chef::Mixin::ShellOut
 
@@ -7,7 +7,7 @@ module AzurePipelines
     class << self
       def release_download_url(version = nil)
         version ||= agent_attrs['version']
-        ::URI.encode "https://vstsagentpackage.azureedge.net/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz"
+        ::CGI::Util.escapeHTML("https://vstsagentpackage.azureedge.net/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz")
       end
 
       def agent_home

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 chef_version '>= 14.0'
-version '3.1.4'
+version '3.1.5'
 
 supports 'mac_os_x'
 


### PR DESCRIPTION
Chef-client 17.10.0 no longer allows the long deprecated URI.encode. Instead, let's use CGI.escapeHTML.