### PR TITLE
Update release_download_url

### DIFF
--- a/libraries/agent.rb
+++ b/libraries/agent.rb
@@ -7,7 +7,7 @@ module AzurePipelines
     class << self
       def release_download_url(version = nil)
         version ||= agent_attrs['version']
-        ::CGI.escapeHTML("https://vstsagentpackage.azureedge.net/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz")
+        ::CGI.escapeHTML("https://download.agent.dev.azure.com/agent/#{version}/vsts-agent-osx-x64-#{version}.tar.gz")
       end
 
       def agent_home

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'A dedicated cookbook for configuring an Azure DevOps build or release agent on macOS.'
 chef_version '>= 14.0'
-version '3.1.5'
+version '3.1.6'
 
 supports 'mac_os_x'
 


### PR DESCRIPTION
We are getting failures in downloading ado agent because it's pointing to a retired CDN. Updating it to point to https://download.agent.dev.azure.com